### PR TITLE
get size from return value

### DIFF
--- a/magento/app/code/community/Uaudio/Storage/Model/League/AwsS3Adapter.php
+++ b/magento/app/code/community/Uaudio/Storage/Model/League/AwsS3Adapter.php
@@ -31,8 +31,8 @@ class Uaudio_Storage_Model_League_AwsS3Adapter extends AwsS3Adapter {
 
         $return = parent::upload($path, $body, $config);
 
-        if(function_exists('getimagesizefromstring') && strpos($mimetype, 'image')!==false) {
-            $size = getimagesizefromstring($body);
+        if(strpos($mimetype, 'image')!==false) {
+            $size = $return['size'];
             $this->s3Client->copyObject([
                 'Bucket' => $this->bucket,
                 'CopySource' => $this->bucket.DS.$key,


### PR DESCRIPTION
getimagesizefromstring() wasn't working on a stream

ERR (3): Warning: getimagesizefromstring() expects parameter 1 to be string, resource given  in /app/code/community/Uaudio/Storage/Model/League/AwsS3Adapter.php on line 35
