### PR TITLE
getLocalDestination method exists in $storageModel, not $this

### DIFF
--- a/magento/app/code/community/Uaudio/Storage/Model/Catalog/Product/Attribute/Backend/Media.php
+++ b/magento/app/code/community/Uaudio/Storage/Model/Catalog/Product/Attribute/Backend/Media.php
@@ -139,7 +139,7 @@ class Uaudio_Storage_Model_Catalog_Product_Attribute_Backend_Media extends Mage_
                 throw new Exception();
             }
 
-            $destFile = $this->getLocalDestination($storageModel->copyFile($filePath, $filePath));
+            $destFile = $storageModel->getLocalDestination($storageModel->copyFile($filePath, $filePath));
 
         } catch (Exception $e) {
             $file = $this->_getConfig()->getMediaPath($file);


### PR DESCRIPTION
Trying to duplicate a magento product with local file storage resulted in PHP fatal: getLocalDestination method not found.