### PR TITLE
Don't md5_file if file doesn't exist

### DIFF
--- a/magento/app/code/community/Uaudio/Storage/Model/Core/Design/Package.php
+++ b/magento/app/code/community/Uaudio/Storage/Model/Core/Design/Package.php
@@ -113,7 +113,7 @@ class Uaudio_Storage_Model_Core_Design_Package extends Mage_Core_Model_Design_Pa
         // merge into target file
         $string = null;
         foreach($files as $file) {
-            $string .= md5_file($file);
+            if (file_exists($file)) $string .= md5_file($file);
         }
         $targetFilename = md5($string."|{$hostname}|{$port}").'.css';
 


### PR DESCRIPTION
This is to fix a php warning if the file doesn't exist:
Warning: md5_file(xxx): failed to open stream: No such file or directory