### PR TITLE
Silence notice on no backend

### DIFF
--- a/magento/app/code/community/Uaudio/Storage/Model/Storage/Abstract.php
+++ b/magento/app/code/community/Uaudio/Storage/Model/Storage/Abstract.php
@@ -118,10 +118,13 @@ abstract class Uaudio_Storage_Model_Storage_Abstract extends Mage_Core_Model_Fil
             $options = Mage::getConfig()->getNode('global/cache');
             $options = $options ? $options->asArray() : [];
 
-            switch($options['backend']) {
-                case 'Cm_Cache_Backend_Redis':
-                    $this->_cache = new Uaudio_Storage_Model_Storage_Cache_Redis();
-                    $this->_cache->setAutosave(false);
+
+            if (isset($options['backend'])) {
+                switch($options['backend']) {
+                    case 'Cm_Cache_Backend_Redis':
+                        $this->_cache = new Uaudio_Storage_Model_Storage_Cache_Redis();
+                        $this->_cache->setAutosave(false);
+                }
             }
         }
         return $this->_cache;


### PR DESCRIPTION
A notice is raised if the $options['backend'] is not set.